### PR TITLE
kubelet: fix cni config by metadata for nodes

### DIFF
--- a/pkg/kubelet/kubeadm-init.sh
+++ b/pkg/kubelet/kubeadm-init.sh
@@ -11,9 +11,6 @@ else
     kubeadm init --skip-preflight-checks --kubernetes-version @KUBERNETES_VERSION@ $@
 fi
 
-if [ -d /var/config/cni/etc/net.d ]; then
-  cp /var/config/cni/etc/net.d/* /var/lib/cni/etc/net.d/
-fi
 # sorting by basename relies on the dirnames having the same number of directories
 YAML=$(ls -1 /var/config/kube-system.init/*.yaml /etc/kubeadm/kube-system.init/*.yaml 2>/dev/null | sort --field-separator=/ --key=5)
 for i in ${YAML}; do

--- a/pkg/kubelet/kubelet.sh
+++ b/pkg/kubelet/kubelet.sh
@@ -21,6 +21,12 @@ if [ ! -e /var/lib/cni/.opt.defaults-extracted ] ; then
     touch /var/lib/cni/.opt.defaults-extracted
 fi
 
+if [ ! -e /var/lib/cni/.cni.configs-extracted ] && [ -d /var/config/cni/etc/net.d ] ; then
+    mkdir -p /var/lib/cni/etc/net.d
+    cp /var/config/cni/etc/net.d/* /var/lib/cni/etc/net.d/
+    touch /var/lib/cni/.cni.configs-extracted
+fi
+
 await=/etc/kubernetes/kubelet.conf
 
 if [ -f "/etc/kubernetes/kubelet.conf" ] ; then

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -36,7 +36,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:b7f21ef1b13300a994e35eac3644e4f84f0ada8a
   - name: kubelet
-    image: linuxkit/kubelet:0c0f4c169aaecb26d1b08115e7a3dd43c5dd8c9d
+    image: linuxkit/kubelet:957424479aa8140c7a309fd7a39976f36b02be92
 files:
   - path: etc/linuxkit.yml
     metadata: yaml


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
move the cni settings copy code from kubeadm-init.sh to kubelet.sh, because kubeadm-init.sh does not get called when `init` is not set in metadata. 
**- How I did it**
**- How to verify it**
write some metadata into "cni/etc/net.d/" and check on nodes and masters.
**- Description for the changelog**
fix cni config by metadata for nodes
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![](https://i.ytimg.com/vi/j2t_l5uTMRA/hqdefault.jpg)