### PR TITLE
Use linuxkit build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,9 @@ jobs:
       - run:
           name: Fetch binaries
           command: |
-            curl -fsSL -o /workspace/bin/linuxkit https://188-46932243-gh.circle-artifacts.com/0/linuxkit-linux-amd64
             curl -fsSL -o /tmp/docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz
             tar xfO /tmp/docker.tgz docker/docker > /workspace/bin/docker
+            curl -fsSL -o /workspace/bin/linuxkit https://188-46932243-gh.circle-artifacts.com/0/linuxkit-linux-amd64
 
             echo "Downloaded:"
             sha256sum /workspace/bin/*
@@ -94,8 +94,8 @@ jobs:
       - run:
           name: Versions
           command: |
-             chmod +x /workspace/bin/linuxkit && /workspace/bin/linuxkit version
              chmod +x /workspace/bin/docker # docker version deferred until daemon configured in relevant jobs
+             chmod +x /workspace/bin/linuxkit && /workspace/bin/linuxkit version
       - persist_to_workspace:
           root: /workspace
           paths: bin

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ KUBE_FORMAT_ARGS := $(patsubst %,-format %,$(KUBE_FORMATS))
 all: kube-master.iso kube-node.iso
 
 kube-master.iso: yml/kube.yml yml/$(KUBE_RUNTIME).yml yml/$(KUBE_RUNTIME)-master.yml yml/$(KUBE_NETWORK).yml
-	moby build -name kube-master $(KUBE_FORMAT_ARGS) $^
+	linuxkit build -name kube-master $(KUBE_FORMAT_ARGS) $^
 
 kube-node.iso: yml/kube.yml yml/$(KUBE_RUNTIME).yml yml/$(KUBE_NETWORK).yml
-	moby build -name kube-node $(KUBE_FORMAT_ARGS) $^
+	linuxkit build -name kube-node $(KUBE_FORMAT_ARGS) $^
 
 yml/weave.yml: kube-weave.yaml
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@ This project aims to demonstrate how one can create minimal and immutable Kubern
 
 ## Build requirements
 
-To build images you will need the [Moby tool](https://github.com/moby/tool), and to rebuild the individual packages you will need the [LinuxKit tool](https://github.com/linuxkit/linuxkit/tree/master/src/cmd/linuxkit)
+To build images and to rebuild the individual packages you will need the [LinuxKit tool](https://github.com/linuxkit/linuxkit/tree/master/src/cmd/linuxkit)
 
-If you already have `go` installed you can use `go get -u github.com/moby/tool/cmd/moby` to install the `moby` build tool, and `go get -u github.com/linuxkit/linuxkit/src/cmd/linuxkit` to install the `linuxkit` tool.
+If you already have `go` installed you can use `go get -u github.com/linuxkit/linuxkit/src/cmd/linuxkit` to install the tool.
 
 On MacOS there is a `brew tap` available. Detailed instructions are at [linuxkit/homebrew-linuxkit](https://github.com/linuxkit/homebrew-linuxkit), the short summary is
 ```
 brew tap linuxkit/linuxkit
-brew install --HEAD moby
 brew install --HEAD linuxkit
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kubernetes and LinuxKit
 
+[![CircleCI](https://circleci.com/gh/linuxkit/kubernetes.svg?style=svg)](https://circleci.com/gh/linuxkit/kubernetes)
+
 This project aims to demonstrate how one can create minimal and immutable Kubernetes OS images with LinuxKit.
 
 ## Build requirements


### PR DESCRIPTION
Drop Moby installation from the README and switch over usage in the Makefile.

Also a couple of CI tweaks:
* Include the badge in the README.
* Download the dependencies in alphabetical order (in a future PR I'm going to add some more downloads, this preempts my retentiveness for that)