### PR TITLE
Bump hashes for containerd v1.0.0 and enable content trust

### DIFF
--- a/pkg/cri-containerd/Dockerfile
+++ b/pkg/cri-containerd/Dockerfile
@@ -16,7 +16,7 @@ ENV GOPATH=/go PATH=$PATH:/go/bin
 
 ENV CRI_CONTAINERD_URL https://github.com/kubernetes-incubator/cri-containerd.git
 #ENV CRI_CONTAINERD_BRANCH pull/NNN/head
-ENV CRI_CONTAINERD_COMMIT ac8b0979fa634703e0a8d03df03eb51774fcff3d
+ENV CRI_CONTAINERD_COMMIT f75fa1e39817f83d3ccaf679518b005380df2880
 RUN mkdir -p $GOPATH/src/github.com/kubernetes-incubator && \
     cd $GOPATH/src/github.com/kubernetes-incubator && \
     git clone $CRI_CONTAINERD_URL cri-containerd

--- a/scripts/update-linuxkit-hashes.sh
+++ b/scripts/update-linuxkit-hashes.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+lkurl="https://github.com/linuxkit/linuxkit"
+
+tdir=$(mktemp -d)
+trap 'if [ -d "$tdir" ] ; then rm -rf $tdir; fi' EXIT
+
+git clone $lkurl $tdir/lk
+
+lkrev=$(git -C $tdir/lk show --oneline -s HEAD)
+
+for i in $tdir/lk/pkg/* ; do
+    if [ ! -d "$i" ] ; then
+	continue
+    fi
+
+    if [ ! -f "$i/build.yml" ] ; then
+	echo "$i does not contain a build.yml" >&2
+	continue
+    fi
+
+    tag=$(linuxkit pkg show-tag "$i")
+    echo "Updating to $tag"
+
+    image=${tag%:*}
+    sed -i -e "s,$image:[[:xdigit:]]\{40\}\(-dirty\)\?,$tag,g" yml/*.yml
+done
+
+# We manually construct the S-o-b because -F strips the trailing blank
+# lines, meaning that with -s there is no blank between the "Commit:
+# ..." and the S-o-b.
+uname=$(git config --get user.name)
+email=$(git config --get user.email)
+
+cat >$tdir/commit-msg <<EOF
+Updated hashes from https://github.com/linuxkit/linuxkit
+
+Commit: $lkrev
+
+Signed-off-by: $uname <$email>
+EOF
+
+git commit --only -F $tdir/commit-msg yml/*.yml

--- a/yml/cri-containerd.yml
+++ b/yml/cri-containerd.yml
@@ -1,6 +1,6 @@
 services:
   - name: cri-containerd
-    image: linuxkit/cri-containerd:9c24ac6197ee725844c4b004e26c66f750309e95
+    image: linuxkit/cri-containerd:13e866007004e919de34eccf828144a3be9c9741
     cgroupsPath: podruntime/runtime
 files:
   - path: /etc/kubelet.sh.conf

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -2,13 +2,13 @@ kernel:
   image: linuxkit/kernel:4.9.62
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:42a92119e1ca10380e0d33e26c0cbcf85b9b3558
+  - linuxkit/init:19ab525233763e1740cd3b9d60cd17141d316776
   - linuxkit/runc:1b0741d07949c0acc444cd6a04ee7f833443579d
-  - linuxkit/containerd:bfb61cc1d26c39cd4b2bc08f7a9963fefa0ef3bf
+  - linuxkit/containerd:a25f471a8ca68e75afad7bf84187adbe70513b8d
   - linuxkit/ca-certificates:af4880e78edc28743f7c5e262678c67c6add4c26
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:a9ad57ed738a31ea9380cd73236866c312b35489
+    image: linuxkit/sysctl:efe693534bb623007f94a2e3ff4a9fd6ead75aa1
     binds:
      - /etc/sysctl.d/01-kubernetes.conf:/etc/sysctl.d/01-kubernetes.conf
     readonly: false


### PR DESCRIPTION
Now that https://github.com/linuxkit/linuxkit/pull/2794 is merged (bumping linuxkit to containerd v1.0.0) add a script to automate hash updates from [linuxkit/linuxkit](https://github.coml/inuxkit/linuxkit) and run it to pull in the latest packages (including containerd v1.0.0).

Also bump cri-containerd to the latest upstream master which includes their bump to containerd v1.0.0 as well.

Lastly, actually enable content trust for `linuxkit` and `library` hub orgs when building images.