### PR TITLE
Enable content trust when building images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ image_build: &image_build
               # Retag to avoid content trust for unpushed images
               local tag=$(cat /workspace/packages/${pkg}.tag)
               docker image tag ${tag} linuxkitcircleci/${pkg}:ci
-              sed -i -e "s,${tag},linuxkitcircleci/${pkg}:ci,g" yml/*.yml
+              sed -i -e "s,image: ${tag}$,image: linuxkitcircleci/${pkg}:ci,g" yml/*.yml
           }
 
           load kubelet
@@ -78,7 +78,7 @@ image_build: &image_build
           echo
           docker image ls --all
           echo
-          git diff
+          git --no-pager diff
     - run:
         name: Build images
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,19 @@ image_build: &image_build
     - run:
         name: Importing packages from workspace
         command: |
-          docker image load --input /workspace/packages/kubelet.tar
+          load() {
+              local pkg=$1
+              docker image load --input /workspace/packages/${pkg}.tar
+          }
+
+          load kubelet
           case "$KUBE_RUNTIME" in
           docker)
-              docker image load --input /workspace/packages/kubernetes-docker-image-cache-common.tar
-              docker image load --input /workspace/packages/kubernetes-docker-image-cache-control-plane.tar
+              load kubernetes-docker-image-cache-common
+              load kubernetes-docker-image-cache-control-plane
               ;;
           cri-containerd)
-              docker image load --input /workspace/packages/cri-containerd.tar
+              load cri-containerd
               ;;
           *)
               echo "Unknown $KUBE_RUNTIME"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,11 @@ image_build: &image_build
           load() {
               local pkg=$1
               docker image load --input /workspace/packages/${pkg}.tar
+
+              # Retag to avoid content trust for unpushed images
+              local tag=$(cat /workspace/packages/${pkg}.tag)
+              docker image tag ${tag} linuxkitcircleci/${pkg}:ci
+              sed -i -e "s,${tag},linuxkitcircleci/${pkg}:ci,g" yml/*.yml
           }
 
           load kubelet
@@ -72,6 +77,8 @@ image_build: &image_build
           esac
           echo
           docker image ls --all
+          echo
+          git diff
     - run:
         name: Build images
         command: |

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -64,3 +64,7 @@ files:
     source: ~/.ssh/id_rsa.pub
     mode: "0600"
     optional: true
+trust:
+  org:
+    - linuxkit
+    - library


### PR DESCRIPTION
I tried this in #21 and failed because newly built images are only local (and hence unsigned) at the point the images get built since we do not push to hub until everything has succeeded.

The middle commit is the interesting one since it avoids this in CI, its commit message says:

>    CI: Retag images before build since they maybe unsigned so far
>    
>    Images are only signed when they are pushed to hub. An image which has only
>    just been built by this CI run will not yet have been pushed (since that
>    happens last) and hence will not be signed.
>    
>    To avoid this and allow images to be built with content trust (for all other
>    images) retag built images and update the yml on the fly to use the retagged
>    versions. Since the hub org used for retagging is not listed in `trust.org` the
>    build wont care that they haven't been signed.
>    
>    We retag all the local packages even if they are not new in this build (i.e.
>    they might already be on hub and be signed), it's hard to determine when this
>    is the case and not really necessary in this context. The content trust will
>    have been checked on pull (done as part of `linuxkit pkg build`).
>    
>    Signed-off-by: Ian Campbell <ijc@docker.com>
