### PR TITLE
Revert "Put containers in the cgroups that Kubernetes recommends"

### DIFF
--- a/yml/docker-master.yml
+++ b/yml/docker-master.yml
@@ -1,4 +1,3 @@
 services:
   - name: kubernetes-docker-image-cache-control-plane
     image: linuxkit/kubernetes-docker-image-cache-control-plane:35e3308dd4752a8c660ffe8acd000adfcfc81039
-    cgroupsPath: podruntime/runtime

--- a/yml/docker.yml
+++ b/yml/docker.yml
@@ -22,10 +22,8 @@ services:
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
     runtime:
       mkdir: ["/var/lib/kubeadm", "/var/lib/cni/etc", "/var/lib/cni/opt", "/var/lib/kubelet-plugins"]
-    cgroupsPath: podruntime/runtime
   - name: kubernetes-docker-image-cache-common
     image: linuxkit/kubernetes-docker-image-cache-common:f7416397346370cdc3e8dbe6348d504e1273d8c7
-    cgroupsPath: podruntime/runtime
 files:
   - path: /etc/kubelet.sh.conf
     contents: ""

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -29,19 +29,14 @@ services:
     image: linuxkit/getty:6af22c32c98536a79230eef000e9abd06b037faa
     env:
      - INSECURE=true
-    cgroupsPath: systemreserved/getty
   - name: rngd
     image: linuxkit/rngd:842e5e8ece7934f0cab9fd0027b595ff3471e5b9
-    cgroupsPath: systemreserved/rngd
   - name: ntpd
     image: linuxkit/openntpd:07a80c3e3e816658318ac027e1253ff9a228b8de
-    cgroupsPath: systemreserved/ntpd
   - name: sshd
     image: linuxkit/sshd:b7f21ef1b13300a994e35eac3644e4f84f0ada8a
-    cgroupsPath: systemreserved/sshd
   - name: kubelet
     image: linuxkit/kubelet:04e7aec28c89d2f408cd8810dd5b752a739f9a63
-    cgroupsPath: podruntime/kubelet
 files:
   - path: etc/linuxkit.yml
     metadata: yaml


### PR DESCRIPTION
This reverts commit 662d3d4e59f9a3ffaaa9133018c177667ab69e75.

Signed-off-by: Ian Campbell <ijc@docker.com>

This is the content of #14 which caused dockerd to die shortly after boot. I've raised #23 to investigate, in the meantime lets back out the change.