### PR TITLE
move socat to cri-containerd container

### DIFF
--- a/pkg/cri-containerd/Dockerfile
+++ b/pkg/cri-containerd/Dockerfile
@@ -10,7 +10,6 @@ RUN \
   libseccomp-dev \
   linux-headers \
   make \
-  socat \
   && true
 ENV GOPATH=/go PATH=$PATH:/go/bin
 
@@ -39,6 +38,7 @@ RUN apk add --no-cache --initdb -p /out \
     ca-certificates \
     iptables \
     util-linux \
+    socat \
     && true
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache

--- a/yml/cri-containerd.yml
+++ b/yml/cri-containerd.yml
@@ -1,6 +1,6 @@
 services:
   - name: cri-containerd
-    image: linuxkit/cri-containerd:13e866007004e919de34eccf828144a3be9c9741
+    image: linuxkit/cri-containerd:179d9a1087d615f3a628e47a73243f8e56fb1440
     cgroupsPath: podruntime/runtime
 files:
   - path: /etc/kubelet.sh.conf


### PR DESCRIPTION
Signed-off-by: Robin Winkelewski <w9ncontact@gmail.com>

move socat from build container to actual container
linuxkit/linuxkit#2639
