### PR TITLE
plumb cni settings

### DIFF
--- a/pkg/cri-containerd/Dockerfile
+++ b/pkg/cri-containerd/Dockerfile
@@ -47,5 +47,5 @@ RUN make DESTDIR=/out install
 
 FROM scratch
 WORKDIR /
-ENTRYPOINT ["cri-containerd", "-v", "2", "--alsologtostderr", "--network-bin-dir", "/var/lib/cni/opt/bin", "--network-conf-dir", "/var/lib/cni/etc/net.d"]
+ENTRYPOINT ["cri-containerd", "-v", "2", "--alsologtostderr", "--network-bin-dir", "/var/lib/cni/opt/bin", "--network-conf-dir", "/var/lib/cni/conf"]
 COPY --from=build /out /

--- a/pkg/cri-containerd/Dockerfile
+++ b/pkg/cri-containerd/Dockerfile
@@ -47,5 +47,5 @@ RUN make DESTDIR=/out install
 
 FROM scratch
 WORKDIR /
-ENTRYPOINT ["cri-containerd", "-v", "2", "--alsologtostderr", "--network-bin-dir", "/var/lib/cni/opt/bin", "--network-conf-dir", "/var/lib/cni/conf"]
+ENTRYPOINT ["cri-containerd", "-v", "2", "--alsologtostderr", "--network-bin-dir", "/opt/cni/bin", "--network-conf-dir", "/etc/cni/net.d"]
 COPY --from=build /out /

--- a/pkg/cri-containerd/build.yml
+++ b/pkg/cri-containerd/build.yml
@@ -11,7 +11,7 @@ config:
   - /tmp:/tmp
   - /var:/var:rshared,rbind
   - /var/lib/kubeadm:/etc/kubernetes
-  - /var/lib/cni/etc:/etc/cni:rshared,rbind
+  - /var/lib/cni/conf:/etc/cni/net.d:rshared,rbind
   - /var/lib/cni/opt:/opt/cni:rshared,rbind
   - /run/containerd/containerd.sock:/run/containerd/containerd.sock
   - /var/lib/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins:rshared,rbind
@@ -30,6 +30,6 @@ config:
   runtime:
     mkdir:
     - /var/lib/kubeadm
-    - /var/lib/cni/etc/net.d
+    - /var/lib/cni/conf
     - /var/lib/cni/opt
     - /var/lib/kubelet-plugins

--- a/pkg/cri-containerd/build.yml
+++ b/pkg/cri-containerd/build.yml
@@ -12,7 +12,7 @@ config:
   - /var:/var:rshared,rbind
   - /var/lib/kubeadm:/etc/kubernetes
   - /var/lib/cni/conf:/etc/cni/net.d:rshared,rbind
-  - /var/lib/cni/opt:/opt/cni:rshared,rbind
+  - /var/lib/cni/bin:/opt/cni/bin:rshared,rbind
   - /run/containerd/containerd.sock:/run/containerd/containerd.sock
   - /var/lib/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins:rshared,rbind
   mounts:
@@ -31,5 +31,5 @@ config:
     mkdir:
     - /var/lib/kubeadm
     - /var/lib/cni/conf
-    - /var/lib/cni/opt
+    - /var/lib/cni/bin
     - /var/lib/kubelet-plugins

--- a/pkg/kubelet/build.yml
+++ b/pkg/kubelet/build.yml
@@ -15,6 +15,7 @@ config:
   - /etc/kubeadm:/etc/kubeadm
   - /var/lib/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins:rshared,rbind
   - /var/lib/cni/conf:/etc/cni/net.d:rshared,rbind
+  - /var/lib/cni/bin:/opt/cni/bin:rshared,rbind
   mounts:
   - type: cgroup
     options:
@@ -31,12 +32,12 @@ config:
     mkdir:
     - /var/lib/kubeadm
     - /var/lib/cni/conf
-    - /var/lib/cni/opt
+    - /var/lib/cni/bin
     - /var/lib/kubelet-plugins
     mounts:
     - type: bind
-      source: /var/lib/cni/opt
-      destination: /opt/cni
+      source: /var/lib/cni/bin
+      destination: /opt/cni/bin
       options:
       - rw
       - bind

--- a/pkg/kubelet/build.yml
+++ b/pkg/kubelet/build.yml
@@ -14,6 +14,7 @@ config:
   - /etc/kubelet.sh.conf:/etc/kubelet.sh.conf
   - /etc/kubeadm:/etc/kubeadm
   - /var/lib/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins:rshared,rbind
+  - /var/lib/cni/conf:/etc/cni/net.d:rshared,rbind
   mounts:
   - type: cgroup
     options:
@@ -29,7 +30,7 @@ config:
   runtime:
     mkdir:
     - /var/lib/kubeadm
-    - /var/lib/cni/etc
+    - /var/lib/cni/conf
     - /var/lib/cni/opt
     - /var/lib/kubelet-plugins
     mounts:
@@ -40,8 +41,8 @@ config:
       - rw
       - bind
     - type: bind
-      source: /var/lib/cni/etc
-      destination: /etc/cni
+      source: /var/lib/cni/conf
+      destination: /etc/cni/net.d
       options:
       - rw
       - bind

--- a/pkg/kubelet/kubelet.sh
+++ b/pkg/kubelet/kubelet.sh
@@ -21,9 +21,9 @@ if [ ! -e /var/lib/cni/.opt.defaults-extracted ] ; then
     touch /var/lib/cni/.opt.defaults-extracted
 fi
 
-if [ ! -e /var/lib/cni/.cni.configs-extracted ] && [ -d /var/config/cni/etc/net.d ] ; then
-    mkdir -p /var/lib/cni/etc/net.d
-    cp /var/config/cni/etc/net.d/* /var/lib/cni/etc/net.d/
+if [ ! -e /var/lib/cni/.cni.conf-extracted ] && [ -d /var/config/cni ] ; then
+    mkdir -p /var/lib/cni/conf
+    cp /var/config/cni/* /var/lib/cni/conf/
     touch /var/lib/cni/.cni.configs-extracted
 fi
 
@@ -72,7 +72,7 @@ exec kubelet --kubeconfig=/etc/kubernetes/kubelet.conf \
 	      --cgroups-per-qos=false \
 	      --enforce-node-allocatable= \
 	      --network-plugin=cni \
-	      --cni-conf-dir=/var/lib/cni/etc/net.d \
+	      --cni-conf-dir=/etc/cni/net.d \
 	      --cni-bin-dir=/var/lib/cni/opt/bin \
 	      --cadvisor-port=0 \
 	      $KUBELET_ARGS $@

--- a/pkg/kubelet/kubelet.sh
+++ b/pkg/kubelet/kubelet.sh
@@ -16,8 +16,8 @@ if [ -n "$KUBELET_DISABLED" ] ; then
 fi
 
 if [ ! -e /var/lib/cni/.opt.defaults-extracted ] ; then
-    mkdir -p /var/lib/cni/opt/bin
-    tar -xzf /root/cni.tgz -C /var/lib/cni/opt/bin
+    mkdir -p /var/lib/cni/bin
+    tar -xzf /root/cni.tgz -C /var/lib/cni/bin
     touch /var/lib/cni/.opt.defaults-extracted
 fi
 
@@ -73,6 +73,6 @@ exec kubelet --kubeconfig=/etc/kubernetes/kubelet.conf \
 	      --enforce-node-allocatable= \
 	      --network-plugin=cni \
 	      --cni-conf-dir=/etc/cni/net.d \
-	      --cni-bin-dir=/var/lib/cni/opt/bin \
+	      --cni-bin-dir=/opt/cni/bin \
 	      --cadvisor-port=0 \
 	      $KUBELET_ARGS $@

--- a/yml/bridge.yml
+++ b/yml/bridge.yml
@@ -6,7 +6,7 @@ onboot:
       - "-c"
       - |
         set -ex
-        cat <<EOF >/var/lib/cni/etc/net.d/10-default.conflist
+        cat <<EOF >/var/lib/cni/conf/10-default.conflist
         {
           "cniVersion": "0.3.1",
           "name": "default",
@@ -36,13 +36,13 @@ onboot:
           ]
         }
         EOF
-        cat <<EOF >/var/lib/cni/etc/net.d/99-loopback.conf
+        cat <<EOF >/var/lib/cni/conf/99-loopback.conf
         {
           "cniVersion": "0.2.0",
           "type": "loopback"
         }
         EOF
     runtime:
-      mkdir: ["/var/lib/cni/etc/net.d"]
+      mkdir: ["/var/lib/cni/conf"]
     binds:
       - /var/lib:/var/lib

--- a/yml/cri-containerd.yml
+++ b/yml/cri-containerd.yml
@@ -1,6 +1,6 @@
 services:
   - name: cri-containerd
-    image: linuxkit/cri-containerd:0a91a4e43787a89c0d4824ea71072e56a29bb833
+    image: linuxkit/cri-containerd:c4146c2fc5a91b6c46b7417305a958a0199f06af
     cgroupsPath: podruntime/runtime
 files:
   - path: /etc/kubelet.sh.conf

--- a/yml/docker.yml
+++ b/yml/docker.yml
@@ -16,12 +16,12 @@ services:
      - /var:/var:rshared,rbind
      - /var/lib/kubeadm:/etc/kubernetes
      - /var/lib/cni/conf:/etc/cni/net.d:rshared,rbind
-     - /var/lib/cni/opt:/opt/cni:rshared,rbind
+     - /var/lib/cni/bin:/opt/cni/bin:rshared,rbind
      - /var/lib/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins:rshared,rbind
     rootfsPropagation: shared
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
     runtime:
-      mkdir: ["/var/lib/kubeadm", "/var/lib/cni/conf", "/var/lib/cni/opt", "/var/lib/kubelet-plugins"]
+      mkdir: ["/var/lib/kubeadm", "/var/lib/cni/conf", "/var/lib/cni/bin", "/var/lib/kubelet-plugins"]
   - name: kubernetes-docker-image-cache-common
     image: linuxkit/kubernetes-docker-image-cache-common:d406f234bf7747ea4f25b8f6d6740f7557ad1255
 files:

--- a/yml/docker.yml
+++ b/yml/docker.yml
@@ -15,13 +15,13 @@ services:
      - /run:/run
      - /var:/var:rshared,rbind
      - /var/lib/kubeadm:/etc/kubernetes
-     - /var/lib/cni/etc:/etc/cni:rshared,rbind
+     - /var/lib/cni/conf:/etc/cni/net.d:rshared,rbind
      - /var/lib/cni/opt:/opt/cni:rshared,rbind
      - /var/lib/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins:rshared,rbind
     rootfsPropagation: shared
     command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
     runtime:
-      mkdir: ["/var/lib/kubeadm", "/var/lib/cni/etc", "/var/lib/cni/opt", "/var/lib/kubelet-plugins"]
+      mkdir: ["/var/lib/kubeadm", "/var/lib/cni/conf", "/var/lib/cni/opt", "/var/lib/kubelet-plugins"]
   - name: kubernetes-docker-image-cache-common
     image: linuxkit/kubernetes-docker-image-cache-common:d406f234bf7747ea4f25b8f6d6740f7557ad1255
 files:

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -36,7 +36,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:ac5e8364e2e9aa8717a3295c51eb60b8c57373d5
   - name: kubelet
-    image: linuxkit/kubelet:11082f2f27278399856d2ec37b112c79bc68c5a6
+    image: linuxkit/kubelet:d581c755f04a8a4060e9947cabe737d6b70fdd1b
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -53,7 +53,7 @@ files:
     contents: 'net.ipv4.ip_forward = 1'
   - path: /opt/cni
     directory: true
-  - path: /etc/cni
+  - path: /etc/cni/net.d
     directory: true
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -51,9 +51,9 @@ files:
     directory: true
   - path: /etc/sysctl.d/01-kubernetes.conf
     contents: 'net.ipv4.ip_forward = 1'
-  - path: /opt/cni
-    directory: true
   - path: /etc/cni/net.d
+    directory: true
+  - path: /opt/cni/bin
     directory: true
   - path: root/.ssh/authorized_keys
     source: ~/.ssh/id_rsa.pub


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Minimize usage of `/var` binding in containers and simplify cni metadata path.
**- How I did it**
Let the cni config persist on `/var/lib/cni/conf` and `/var/lib/cni/bin`. 
then mount share them to their default position in `/etc/cni/net.d` and `/opt/cni/bin` in docker, kubelet and hostroot (cri-containerd mounts weave pods HostPath here).
**- How to verify it**
I run both cluster types.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
plumb cni settings

**- A picture of a cute animal (not mandatory but encouraged)**
![](http://ichef.bbci.co.uk/wwfeatures/wm/live/624_351/images/live/p0/1x/vf/p01xvfn0.jpg)
