### PR TITLE
Various build system updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ image_build: &image_build
           df -h .
           # KUBE_FORMATS="iso-efi iso-bios" times out or fails for larger docker images.
           # Just do tar for now.
-          make KUBE_FORMATS="tar" kube-master.iso kube-node.iso
+          make KUBE_FORMATS="tar" master node
           #mv kube-master*.iso kube-node*.iso /workspace/images/kube-$KUBE_RUNTIME-$KUBE_NETWORK
 
 version: 2

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ KUBE_FORMAT_ARGS := $(patsubst %,-format %,$(KUBE_FORMATS))
 all: kube-master.iso kube-node.iso
 
 kube-master.iso: yml/kube.yml yml/$(KUBE_RUNTIME).yml yml/$(KUBE_RUNTIME)-master.yml yml/$(KUBE_NETWORK).yml
-	linuxkit build -name kube-master $(KUBE_FORMAT_ARGS) $^
+	linuxkit $(LINUXKIT_ARGS) build $(LINUXKIT_BUILD_ARGS) -name kube-master $(KUBE_FORMAT_ARGS) $^
 
 kube-node.iso: yml/kube.yml yml/$(KUBE_RUNTIME).yml yml/$(KUBE_NETWORK).yml
-	linuxkit build -name kube-node $(KUBE_FORMAT_ARGS) $^
+	linuxkit $(LINUXKIT_ARGS) build $(LINUXKIT_BUILD_ARGS) -name kube-node $(KUBE_FORMAT_ARGS) $^
 
 yml/weave.yml: kube-weave.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,13 @@ endif
 
 KUBE_FORMAT_ARGS := $(patsubst %,-format %,$(KUBE_FORMATS))
 
-all: kube-master.iso kube-node.iso
+.PHONY: all master node
+all: master node
 
-kube-master.iso: yml/kube.yml yml/$(KUBE_RUNTIME).yml yml/$(KUBE_RUNTIME)-master.yml yml/$(KUBE_NETWORK).yml
+master: yml/kube.yml yml/$(KUBE_RUNTIME).yml yml/$(KUBE_RUNTIME)-master.yml yml/$(KUBE_NETWORK).yml
 	linuxkit $(LINUXKIT_ARGS) build $(LINUXKIT_BUILD_ARGS) -name kube-master $(KUBE_FORMAT_ARGS) $^
 
-kube-node.iso: yml/kube.yml yml/$(KUBE_RUNTIME).yml yml/$(KUBE_NETWORK).yml
+node: yml/kube.yml yml/$(KUBE_RUNTIME).yml yml/$(KUBE_NETWORK).yml
 	linuxkit $(LINUXKIT_ARGS) build $(LINUXKIT_BUILD_ARGS) -name kube-node $(KUBE_FORMAT_ARGS) $^
 
 yml/weave.yml: kube-weave.yaml

--- a/boot.sh
+++ b/boot.sh
@@ -88,4 +88,4 @@ if [ -n "${kubeadm_data}" ] ; then
     echo "{  \"kubeadm\": { \"entries\": { ${kubeadm_data} } } }" > $state/metadata.json
 fi
 
-linuxkit run ${KUBE_RUN_ARGS} -networking ${KUBE_NETWORKING} -cpus ${KUBE_VCPUS} -mem ${KUBE_MEM} -state "${state}" -disk size=${KUBE_DISK} -data $state/metadata.json ${uefi} "${img}${suffix}"
+exec linuxkit run ${KUBE_RUN_ARGS} -networking ${KUBE_NETWORKING} -cpus ${KUBE_VCPUS} -mem ${KUBE_MEM} -state "${state}" -disk size=${KUBE_DISK} -data $state/metadata.json ${uefi} "${img}${suffix}"

--- a/ssh_into_kubelet.sh
+++ b/ssh_into_kubelet.sh
@@ -3,7 +3,8 @@
 sshopts="-o LogLevel=FATAL \
 	 -o StrictHostKeyChecking=no \
 	 -o UserKnownHostsFile=/dev/null \
-	 -o IdentitiesOnly=yes"
+	 -o IdentitiesOnly=yes \
+	 ${SSHOPTS:-}"
 
 case $(uname -s) in
     Linux)
@@ -15,4 +16,4 @@ case $(uname -s) in
 	    ijc25/alpine-ssh"
 	;;
 esac
-$ssh $sshopts -t root@"$1" ctr tasks exec --tty --exec-id ssh-$(hostname)-$$ kubelet ash -l
+exec $ssh $sshopts -t root@"$1" ctr tasks exec --tty --exec-id ssh-$(hostname)-$$ kubelet ash -l


### PR DESCRIPTION
* Add make variables to add options to linuxkit build, useful for adding `-disable-content-trust` etc.
* Use generic make targets `master` and `node` instead of `kube-master.iso` since the result may not be a file with that name anyway depending on setting.
* boot.sh: exec linuxkit so it replaces the shell/wrapper
* ssh: Support user supplied $SSHOPTS and exec ssh