### PR TITLE
enable masquerading in bridged configurations

### DIFF
--- a/yml/bridge.yml
+++ b/yml/bridge.yml
@@ -15,7 +15,7 @@ onboot:
               "type": "bridge",
               "bridge": "cni0",
               "isDefaultGateway": true,
-              "ipMasq": false,
+              "ipMasq": true,
               "hairpinMode": true,
               "ipam": {
                 "type": "host-local",

--- a/yml/bridge.yml
+++ b/yml/bridge.yml
@@ -1,7 +1,47 @@
 onboot:
   - name: bridge
     image: busybox:latest
-    command: ["/bin/sh", "-c", "set -ex; echo '{\"cniVersion\":\"0.3.1\",\"name\":\"default\",\"plugins\":[{\"type\":\"bridge\",\"bridge\":\"cni0\",\"isDefaultGateway\":true,\"ipMasq\":false,\"hairpinMode\":true,\"ipam\":{\"type\":\"host-local\",\"subnet\":\"10.1.0.0/16\",\"gateway\":\"10.1.0.1\"},\"dns\":{\"nameservers\":[\"10.1.0.1\"]}},{\"type\":\"portmap\",\"capabilities\":{\"portMappings\":true},\"snat\":true}]}' > /var/lib/cni/etc/net.d/10-default.conflist; echo '{\"cniVersion\":\"0.2.0\",\"type\":\"loopback\"}' > /var/lib/cni/etc/net.d/99-loopback.conf"]
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        set -ex
+        cat <<EOF >/var/lib/cni/etc/net.d/10-default.conflist
+        {
+          "cniVersion": "0.3.1",
+          "name": "default",
+          "plugins": [
+            {
+              "type": "bridge",
+              "bridge": "cni0",
+              "isDefaultGateway": true,
+              "ipMasq": false,
+              "hairpinMode": true,
+              "ipam": {
+                "type": "host-local",
+                "subnet": "10.1.0.0/16",
+                "gateway": "10.1.0.1"
+              },
+              "dns": {
+                "nameservers": ["10.1.0.1"]
+              }
+            },
+            {
+              "type": "portmap",
+              "capabilities": {
+                "portMappings": true
+              },
+              "snat": true
+            }
+          ]
+        }
+        EOF
+        cat <<EOF >/var/lib/cni/etc/net.d/99-loopback.conf
+        {
+          "cniVersion": "0.2.0",
+          "type": "loopback"
+        }
+        EOF
     runtime:
       mkdir: ["/var/lib/cni/etc/net.d"]
     binds:


### PR DESCRIPTION
Since the internal addresses are not generally externally routed this is a
sensible default so that pods can talk to the outside world, or rather so the
outside world can talk back.

Signed-off-by: Ian Campbell <ijc@docker.com>

I also took the opportunity to make this file more readable, the changes are more obvious in the commits themselves than in the PR overview.

Initially reported in https://github.com/docker/for-mac/issues/2316.
