### PR TITLE
Build cni and cri tools

### DIFF
--- a/pkg/kubelet/Dockerfile
+++ b/pkg/kubelet/Dockerfile
@@ -34,6 +34,20 @@ RUN set -e; \
 
 RUN make WHAT="cmd/kubelet cmd/kubectl cmd/kubeadm"
 
+ENV CNI_URL https://github.com/containernetworking/plugins
+#ENV CNI_BRANCH pull/NNN/head
+ENV CNI_COMMIT ${cni_version}
+RUN mkdir -p $GOPATH/github.com/containernetworking/ && \
+    cd $GOPATH/github.com/containernetworking/ && \
+    git clone $CNI_URL plugins
+WORKDIR $GOPATH/github.com/containernetworking/plugins
+RUN set -e;  \
+    if [ -n "$CNI_BRANCH" ] ; then \
+        git fetch origin "CNI_BRANCH"; \
+    fi; \
+    git checkout $CNI_COMMIT
+RUN ./build.sh
+
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 #coreutils needed for du -B for disk image checks made by kubelet
 # example: $ du -s -B 1 /var/lib/kubelet/pods/...
@@ -55,16 +69,16 @@ RUN apk add --no-cache --initdb -p /out \
     util-linux \
     && true
 
-RUN cp _output/bin/kubelet /out/usr/bin/kubelet
-RUN cp _output/bin/kubeadm /out/usr/bin/kubeadm
-RUN cp _output/bin/kubectl /out/usr/bin/kubectl
+RUN cp $GOPATH/src/github.com/kubernetes/kubernetes/_output/bin/kubelet /out/usr/bin/kubelet
+RUN cp $GOPATH/src/github.com/kubernetes/kubernetes/_output/bin/kubeadm /out/usr/bin/kubeadm
+RUN cp $GOPATH/src/github.com/kubernetes/kubernetes/_output/bin/kubectl /out/usr/bin/kubectl
+
+RUN tar -czf /out/root/cni.tgz -C $GOPATH/github.com/containernetworking/plugins/bin .
 
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
 
 RUN rmdir /out/var/run && ln -nfs /run /out/var/run
-
-RUN curl -fSL -o /out/root/cni.tgz https://github.com/containernetworking/plugins/releases/download/${cni_version}/cni-plugins-amd64-${cni_version}.tgz
 
 ADD kubelet.sh /out/usr/bin/kubelet.sh
 ADD kubeadm-init.sh /kubeadm-init.sh

--- a/pkg/kubelet/Dockerfile
+++ b/pkg/kubelet/Dockerfile
@@ -87,7 +87,6 @@ RUN apk add --no-cache --initdb -p /out \
     ethtool \
     iproute2 \
     iptables \
-    libc6-compat \
     musl \
     openssl \
     socat \

--- a/pkg/kubelet/Dockerfile
+++ b/pkg/kubelet/Dockerfile
@@ -2,6 +2,7 @@ FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
 ENV kubernetes_version v1.9.0
 ENV cni_version        v0.6.0
+ENV critools_version   v1.0.0-alpha.0
 
 RUN apk add -U --no-cache \
   bash \
@@ -19,6 +20,8 @@ RUN apk add -U --no-cache \
 
 ENV GOPATH=/go PATH=$PATH:/go/bin
 
+### Kubernetes (incl Kubelet)
+
 ENV KUBERNETES_URL https://github.com/kubernetes/kubernetes.git
 #ENV KUBERNETES_BRANCH pull/NNN/head
 ENV KUBERNETES_COMMIT ${kubernetes_version}
@@ -34,6 +37,8 @@ RUN set -e; \
 
 RUN make WHAT="cmd/kubelet cmd/kubectl cmd/kubeadm"
 
+### CNI plugins
+
 ENV CNI_URL https://github.com/containernetworking/plugins
 #ENV CNI_BRANCH pull/NNN/head
 ENV CNI_COMMIT ${cni_version}
@@ -47,6 +52,24 @@ RUN set -e;  \
     fi; \
     git checkout $CNI_COMMIT
 RUN ./build.sh
+
+### critools
+
+ENV CRITOOLS_URL https://github.com/kubernetes-incubator/cri-tools
+#ENV CRITOOLS_BRANCH pull/NNN/head
+ENV CRITOOLS_COMMIT ${critools_version}
+RUN mkdir -p $GOPATH/github.com/kubernetes-incubator/ && \
+    cd $GOPATH/github.com/kubernetes-incubator/ && \
+    git clone $CRITOOLS_URL cri-tools
+WORKDIR $GOPATH/github.com/kubernetes-incubator/cri-tools
+RUN set -e;  \
+    if [ -n "$CRITOOLS_BRANCH" ] ; then \
+        git fetch origin "CRITOOLS_BRANCH"; \
+    fi; \
+    git checkout $CRITOOLS_COMMIT
+RUN make binaries
+
+## Construct final image
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 #coreutils needed for du -B for disk image checks made by kubelet
@@ -74,6 +97,9 @@ RUN cp $GOPATH/src/github.com/kubernetes/kubernetes/_output/bin/kubeadm /out/usr
 RUN cp $GOPATH/src/github.com/kubernetes/kubernetes/_output/bin/kubectl /out/usr/bin/kubectl
 
 RUN tar -czf /out/root/cni.tgz -C $GOPATH/github.com/containernetworking/plugins/bin .
+
+RUN cp $GOPATH/bin/crictl /out/usr/bin/crictl
+RUN cp $GOPATH/bin/critest /out/usr/bin/critest
 
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache

--- a/pkg/kubelet/Dockerfile
+++ b/pkg/kubelet/Dockerfile
@@ -1,5 +1,7 @@
 FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
 
+# When changing kubernetes_version remember to also update:
+# - scripts/mk-image-cache-lst and run `make refresh-image-caches` from top-level
 ENV kubernetes_version v1.9.0
 ENV cni_version        v0.6.0
 ENV critools_version   v1.0.0-alpha.0

--- a/scripts/mk-image-cache-lst
+++ b/scripts/mk-image-cache-lst
@@ -1,21 +1,23 @@
 #!/bin/sh
 repo=gcr.io/google_containers
-kube_version=v1.9.0
+# When changing kubernetes_version remember to also update:
+# - pkg/kubelet/Dockerfile
+kubernetes_version=v1.9.0
 kube_dns_version=1.14.7
 pause_version=3.0
 etcd_version=3.1.10
 
 common="
-	kube-proxy-amd64:$kube_version
+	kube-proxy-amd64:$kubernetes_version
 	k8s-dns-sidecar-amd64:$kube_dns_version
 	k8s-dns-kube-dns-amd64:$kube_dns_version
 	k8s-dns-dnsmasq-nanny-amd64:$kube_dns_version
 	pause-amd64:$pause_version"
 
 control="
-	kube-apiserver-amd64:$kube_version
-	kube-controller-manager-amd64:$kube_version
-	kube-scheduler-amd64:$kube_version
+	kube-apiserver-amd64:$kubernetes_version
+	kube-controller-manager-amd64:$kubernetes_version
+	kube-scheduler-amd64:$kubernetes_version
 	etcd-amd64:$etcd_version"
 
 oi() {

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -36,7 +36,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:ac5e8364e2e9aa8717a3295c51eb60b8c57373d5
   - name: kubelet
-    image: linuxkit/kubelet:e9f1fba120ca36a56f0a3aa90b47ad9d3547101e
+    image: linuxkit/kubelet:03205e3daddfeedeb64d4e023b42c225c8e00945
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -36,7 +36,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:ac5e8364e2e9aa8717a3295c51eb60b8c57373d5
   - name: kubelet
-    image: linuxkit/kubelet:76e765ee2731b17bb7d8018177da35eb4a25465f
+    image: linuxkit/kubelet:3722107a1b26d73a40491e9596f503bead9c6573
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -36,7 +36,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:ac5e8364e2e9aa8717a3295c51eb60b8c57373d5
   - name: kubelet
-    image: linuxkit/kubelet:3722107a1b26d73a40491e9596f503bead9c6573
+    image: linuxkit/kubelet:e9f1fba120ca36a56f0a3aa90b47ad9d3547101e
 files:
   - path: etc/linuxkit.yml
     metadata: yaml

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -36,7 +36,7 @@ services:
   - name: sshd
     image: linuxkit/sshd:ac5e8364e2e9aa8717a3295c51eb60b8c57373d5
   - name: kubelet
-    image: linuxkit/kubelet:d581c755f04a8a4060e9947cabe737d6b70fdd1b
+    image: linuxkit/kubelet:76e765ee2731b17bb7d8018177da35eb4a25465f
 files:
   - path: etc/linuxkit.yml
     metadata: yaml


### PR DESCRIPTION
Build CNI binaries ourselves rather than shipping prebuilt binaries.
Add the cri tool binaries (`crictl` and `critest`) also built from source.
Add a comment next to both definitions of `kubernetes_version` cross-referencing the other for updates (should incorporate #35 at some point too).