### PR TITLE
mk-image-cache-lst: fix missing $repo use

### DIFF
--- a/scripts/mk-image-cache-lst
+++ b/scripts/mk-image-cache-lst
@@ -23,7 +23,7 @@ control="
 oi() {
 	local i="$1"
 	digest=$(docker image inspect --format '{{index .RepoDigests 0}}' "$repo/$i")
-	echo "gcr.io/google_containers/${i}@${digest#*@}"
+	echo "$repo/${i}@${digest#*@}"
 }
 
 if [ $# -ne 1 ] ; then


### PR DESCRIPTION
just a small fix to use images from other repos