### PR TITLE
Bump to latest linuxkit hashes, cri beta.1 & Docker 17.12

### DIFF
--- a/pkg/cri-containerd/Dockerfile
+++ b/pkg/cri-containerd/Dockerfile
@@ -15,7 +15,7 @@ ENV GOPATH=/go PATH=$PATH:/go/bin
 
 ENV CRI_CONTAINERD_URL https://github.com/kubernetes-incubator/cri-containerd.git
 #ENV CRI_CONTAINERD_BRANCH pull/NNN/head
-ENV CRI_CONTAINERD_COMMIT v1.0.0-beta.0
+ENV CRI_CONTAINERD_COMMIT v1.0.0-beta.1
 RUN mkdir -p $GOPATH/src/github.com/kubernetes-incubator && \
     cd $GOPATH/src/github.com/kubernetes-incubator && \
     git clone $CRI_CONTAINERD_URL cri-containerd

--- a/pkg/cri-containerd/Dockerfile
+++ b/pkg/cri-containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
+FROM linuxkit/alpine:4584958639b2378246371fe219f33b270667e22e AS build
 
 RUN \
   apk add \

--- a/pkg/kube-e2e-test/Dockerfile
+++ b/pkg/kube-e2e-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
+FROM linuxkit/alpine:4584958639b2378246371fe219f33b270667e22e AS build
 
 # When changing kubernetes_version remember to also update:
 # - scripts/mk-image-cache-lst and run `make refresh-image-caches` from top-level
@@ -40,6 +40,7 @@ RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
     alpine-baselayout \
     bash \
+    busybox \
     ca-certificates \
     curl \
     musl \
@@ -53,8 +54,6 @@ RUN cp _output/bin/e2e.test /out/usr/bin/e2e.test
 
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
-
-RUN rmdir /out/var/run && ln -nfs /run /out/var/run
 
 ADD in-cluster-config.yaml /out/etc/in-cluster-config.yaml
 ADD e2e.sh /out/usr/bin/e2e.sh

--- a/pkg/kubelet/Dockerfile
+++ b/pkg/kubelet/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
+FROM linuxkit/alpine:4584958639b2378246371fe219f33b270667e22e AS build
 
 # When changing kubernetes_version remember to also update:
 # - scripts/mk-image-cache-lst and run `make refresh-image-caches` from top-level
@@ -105,8 +105,6 @@ RUN cp $GOPATH/bin/critest /out/usr/bin/critest
 
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
-
-RUN rmdir /out/var/run && ln -nfs /run /out/var/run
 
 ADD kubelet.sh /out/usr/bin/kubelet.sh
 ADD kubeadm-init.sh /kubeadm-init.sh

--- a/pkg/kubernetes-docker-image-cache-common/Dockerfile
+++ b/pkg/kubernetes-docker-image-cache-common/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
+FROM linuxkit/alpine:4584958639b2378246371fe219f33b270667e22e AS build
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -7,8 +7,6 @@ RUN apk add --no-cache --initdb -p /out \
 
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
-
-RUN rmdir /out/var/run && ln -nfs /run /out/var/run
 
 FROM scratch
 WORKDIR /

--- a/pkg/kubernetes-docker-image-cache-control-plane/Dockerfile
+++ b/pkg/kubernetes-docker-image-cache-control-plane/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:07f7d136e427dc68154cd5edbb2b9576f9ac5213 AS build
+FROM linuxkit/alpine:4584958639b2378246371fe219f33b270667e22e AS build
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \
@@ -7,8 +7,6 @@ RUN apk add --no-cache --initdb -p /out \
 
 # Remove apk residuals. We have a read-only rootfs, so apk is of no use.
 RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
-
-RUN rmdir /out/var/run && ln -nfs /run /out/var/run
 
 FROM scratch
 WORKDIR /

--- a/scripts/update-linuxkit-hashes.sh
+++ b/scripts/update-linuxkit-hashes.sh
@@ -27,6 +27,22 @@ for i in $tdir/lk/pkg/* ; do
     sed -i -e "s,$image:[[:xdigit:]]\{40\}\(-dirty\)\?,$tag,g" yml/*.yml
 done
 
+# Kernel doesn't use `linuxkit pkg` and uses a different
+# tagging strategy, so we do it manually by extracting the
+# "recommended" one from the toplevel linuxkit.yml
+# example.
+# TODO: add a target to kernel/Makefile which will show
+# the recommended kernel.
+tag=$(sed -n -e 's,^\s*image: \(linuxkit/kernel:.\+\)\s*,\1,p' $tdir/lk/linuxkit.yml)
+if [ ! -n "$tag" ] ; then
+    echo "Failed to extract kernel tag" >&2
+    exit 1
+fi
+# Not update_hash since the tag is not a hash in this case
+
+echo "Updating to $tag"
+sed -i -e "s,linuxkit/kernel:.\+,$tag,g" yml/*.yml
+
 # We manually construct the S-o-b because -F strips the trailing blank
 # lines, meaning that with -s there is no blank between the "Commit:
 # ..." and the S-o-b.

--- a/ssh_into_kubelet.sh
+++ b/ssh_into_kubelet.sh
@@ -16,4 +16,4 @@ case $(uname -s) in
 	    ijc25/alpine-ssh"
 	;;
 esac
-exec $ssh $sshopts -t root@"$1" ctr tasks exec --tty --exec-id ssh-$(hostname)-$$ kubelet ash -l
+exec $ssh $sshopts -t root@"$1" ctr --namespace services.linuxkit tasks exec --tty --exec-id ssh-$(hostname)-$$ kubelet ash -l

--- a/yml/cri-containerd.yml
+++ b/yml/cri-containerd.yml
@@ -1,6 +1,6 @@
 services:
   - name: cri-containerd
-    image: linuxkit/cri-containerd:456231d577a273334cee9b99761410cfc29d9811
+    image: linuxkit/cri-containerd:6d7a253f3e69c506c76f0a0dfa32b7c307b0c9ee
     cgroupsPath: podruntime/cri-containerd
 files:
   - path: /etc/kubelet.sh.conf

--- a/yml/cri-containerd.yml
+++ b/yml/cri-containerd.yml
@@ -1,6 +1,6 @@
 services:
   - name: cri-containerd
-    image: linuxkit/cri-containerd:35f4761216380fe80a120ba7fa2d52545847cc13
+    image: linuxkit/cri-containerd:456231d577a273334cee9b99761410cfc29d9811
     cgroupsPath: podruntime/cri-containerd
 files:
   - path: /etc/kubelet.sh.conf

--- a/yml/docker-master.yml
+++ b/yml/docker-master.yml
@@ -1,4 +1,4 @@
 services:
   - name: kubernetes-docker-image-cache-control-plane
-    image: linuxkit/kubernetes-docker-image-cache-control-plane:3606d4714909c0916f68f2ac96fc728c4d9de316
+    image: linuxkit/kubernetes-docker-image-cache-control-plane:d486ce15b5dedc742684849dd9d61b8d59d9624b
     cgroupsPath: podruntime/control-cache

--- a/yml/docker.yml
+++ b/yml/docker.yml
@@ -24,7 +24,7 @@ services:
       mkdir: ["/var/lib/kubeadm", "/var/lib/cni/conf", "/var/lib/cni/bin", "/var/lib/kubelet-plugins"]
     cgroupsPath: podruntime/docker
   - name: kubernetes-docker-image-cache-common
-    image: linuxkit/kubernetes-docker-image-cache-common:434f337a5338776f67ab34e2327489c1368f2559
+    image: linuxkit/kubernetes-docker-image-cache-common:9d0f7a513998ae3fdaf9089655aa9e9118e938f1
     cgroupsPath: podruntime/common-cache
 files:
   - path: /etc/kubelet.sh.conf

--- a/yml/docker.yml
+++ b/yml/docker.yml
@@ -1,6 +1,6 @@
 services:
   - name: docker
-    image: docker:17.11.0-ce-dind
+    image: docker:17.12.0-ce-dind
     capabilities:
      - all
     pid: host

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -1,14 +1,14 @@
 kernel:
-  image: linuxkit/kernel:4.9.62
+  image: linuxkit/kernel:4.9.75
   cmdline: "console=tty0 console=ttyS0"
 init:
-  - linuxkit/init:9250948d0de494df8a811edb3242b4584057cfe4
+  - linuxkit/init:26def2174c74efa0ea8006ebd63ebb5d02e9513e
   - linuxkit/runc:abc3f292653e64a2fd488e9675ace19a55ec7023
   - linuxkit/containerd:e58a382c33bb509ba3e0e8170dfaa5a100504c5b
   - linuxkit/ca-certificates:de21b84d9b055ad9dcecc57965b654a7a24ef8e0
 onboot:
   - name: sysctl
-    image: linuxkit/sysctl:ce3bde5118a41092f1b7048c85d14fb35237ed45
+    image: linuxkit/sysctl:4c1ef93bb5eb1a877318db4b2daa6768ed002e21
     binds:
      - /etc/sysctl.d/01-kubernetes.conf:/etc/sysctl.d/01-kubernetes.conf
     readonly: false
@@ -40,7 +40,7 @@ services:
     image: linuxkit/sshd:ac5e8364e2e9aa8717a3295c51eb60b8c57373d5
     cgroupsPath: systemreserved/sshd
   - name: kubelet
-    image: linuxkit/kubelet:e9b7f3fda7b13331fc5ec07570174df8e8d470ad
+    image: linuxkit/kubelet:0e6902fbb878f592b8be03605e18d917e622ce31
     cgroupsPath: podruntime/kubelet
     runtime:
       cgroups:


### PR DESCRIPTION
This picks up a new init package with https://github.com/linuxkit/linuxkit/pull/2809 included and hence all the LinuxKit services are now in the `services.linuxkit` containerd namespace. This means they won't show in `ctr` by default unless you use the `--namespace` option or set `CONTAINERD_NAMESPACE=services.linuxkit` in your shell environment.

Also ensure that the script picks up the latest recommended kernel (currently as inferred from the `linuxkit.yml` example). This picks up a bunch of Spectre/Meltdown related fixes to the kernel. There are some sysctl based mitigations in that package update..