### PR TITLE
Portable `make update-hashes`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ update-hashes:
 	           $$(linuxkit pkg show-tag pkg/kubernetes-docker-image-cache-common) \
 	           $$(linuxkit pkg show-tag pkg/kubernetes-docker-image-cache-control-plane) ; do \
 	    image=$${tag%:*} ; \
-	    git grep -E -l "\b$$image:" | xargs --no-run-if-empty sed -i.bak -e "s,$$image:[[:xdigit:]]\{40\}\(-dirty\)\?,$$tag,g" ; \
+	    sed -i.bak -e "s,$$image:[[:xdigit:]]\{40\}\(-dirty\)\?,$$tag,g" yml/*.yml ; \
 	done
 
 .PHONY: clean


### PR DESCRIPTION
MacOS lacks `xargs`' `--no-run-if-empty` option. Since the `git grep` always
matches at least one file it's not really needed.

However since the files which need patching are just those under yml/ which are
small enough in number and size that we can just unconditionally apply the
update to the all.

Fixes #52.

Signed-off-by: Ian Campbell <ijc@docker.com>
