### PR TITLE
Portable `sed` expression for `make update-hashes`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ update-hashes:
 	           $$(linuxkit pkg show-tag pkg/kubernetes-docker-image-cache-common) \
 	           $$(linuxkit pkg show-tag pkg/kubernetes-docker-image-cache-control-plane) ; do \
 	    image=$${tag%:*} ; \
-	    sed -i.bak -e "s,$$image:[[:xdigit:]]\{40\}\(-dirty\)\?,$$tag,g" yml/*.yml ; \
+	    sed -E -i.bak -e "s,$$image:[[:xdigit:]]{40}(-dirty)?,$$tag,g" yml/*.yml ; \
 	done
 
 .PHONY: clean


### PR DESCRIPTION
While #55 fixed the issue with `xargs` it did not fix the `sed` expression to
work on MacOS. Do so by enabling extended regular expressions (`-E`) and
adjusting the expression, this now works on both Linux (GNU sed 4.4) and on
MacOS (system `sed` from FreeBSD).

This properly fixes #52.

Signed-off-by: Ian Campbell <ijc@docker.com>
