### PR TITLE
Revert "Drop duplicate mounts of CNI directories."

### DIFF
--- a/pkg/kubelet/build.yml
+++ b/pkg/kubelet/build.yml
@@ -36,3 +36,12 @@ config:
     - /var/lib/cni/bin
     - /var/lib/kubelet-plugins
     - /var/lib/nfs/statd/sm
+    mounts:
+    - type: bind
+      source: /var/lib/cni/bin
+      destination: /opt/cni/bin
+      options: ["rw","bind"]
+    - type: bind
+      source: /var/lib/cni/conf
+      destination: /etc/cni/net.d
+      options: ["rw","bind"]

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -40,7 +40,7 @@ services:
     image: linuxkit/sshd:4f403fe5ae53dc3e45c8f6972dced9dddf900ae6
     cgroupsPath: systemreserved/sshd
   - name: kubelet
-    image: linuxkit/kubelet:0513947feba7c6cdf5d8d815fb776a99011307ff
+    image: linuxkit/kubelet:1b3b31281092aef89c39107aeed90299aeaa19a7
     cgroupsPath: podruntime/kubelet
 files:
   - path: etc/linuxkit.yml


### PR DESCRIPTION
This reverts commit 81e895368eb7dfc295c7954027b5b051aaed583f.

These mounts are apparently not as redundant as they first seemed. The
`runtimes.mounts` paths are all wrt the host mount namespace, so these are in
fact binding the (writeable) `/var/lib/cni` paths over the (readonly) canonical
host CNI paths. The `binds` will then bind those host paths into the kubelet
container.

Fixes #59, I also saw this during development of #58.

Signed-off-by: Ian Campbell <ijc@docker.com>
