### PR TITLE
Cni bridge configurability

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -85,7 +85,7 @@ fi
 mkdir -p "${state}"
 touch $state/metadata.json
 if [ -n "${kubeadm_data}" ] ; then
-    echo "{  \"kubeadm\": { \"entries\": { ${kubeadm_data} } } }" > $state/metadata.json
+    echo "{ \"kubeadm\": { \"entries\": { ${kubeadm_data} } } }" > $state/metadata.json
 fi
 
 exec linuxkit run ${KUBE_RUN_ARGS} -networking ${KUBE_NETWORKING} -cpus ${KUBE_VCPUS} -mem ${KUBE_MEM} -state "${state}" -disk size=${KUBE_DISK} -data-file $state/metadata.json ${uefi} "${img}${suffix}"

--- a/boot.sh
+++ b/boot.sh
@@ -85,7 +85,11 @@ fi
 mkdir -p "${state}"
 touch $state/metadata.json
 if [ -n "${kubeadm_data}" ] ; then
-    echo "{ \"kubeadm\": { \"entries\": { ${kubeadm_data} } } }" > $state/metadata.json
+    metadata="${metadata:+$metadata, }\"kubeadm\": { \"entries\": { ${kubeadm_data} } }"
+fi
+if [ -n "${metadata}" ] ; then
+    metadata="{ ${metadata} }"
+    echo "${metadata}" > $state/metadata.json
 fi
 
 exec linuxkit run ${KUBE_RUN_ARGS} -networking ${KUBE_NETWORKING} -cpus ${KUBE_VCPUS} -mem ${KUBE_MEM} -state "${state}" -disk size=${KUBE_DISK} -data-file $state/metadata.json ${uefi} "${img}${suffix}"

--- a/boot.sh
+++ b/boot.sh
@@ -17,6 +17,8 @@ set -e
 : ${KUBE_MAC:=}
 : ${KUBE_CLEAR_STATE:=}
 
+: ${KUBE_METADATA:=} # Without the outermost braces {}.
+
 [ "$(uname -s)" = "Darwin" ] && KUBE_EFI=1
 
 suffix=".iso"
@@ -84,6 +86,9 @@ fi
 
 mkdir -p "${state}"
 touch $state/metadata.json
+if [ -n "${KUBE_METADATA}" ] ; then
+    metadata="${metadata:+$metadata, }${KUBE_METADATA}"
+fi
 if [ -n "${kubeadm_data}" ] ; then
     metadata="${metadata:+$metadata, }\"kubeadm\": { \"entries\": { ${kubeadm_data} } }"
 fi

--- a/boot.sh
+++ b/boot.sh
@@ -28,10 +28,10 @@ if [ $# -eq 0 ] ; then
     # then we configure for auto init. If it is completely unset then
     # we do not.
     if [ -n "${KUBE_MASTER_AUTOINIT+x}" ] ; then
-	kubeadm_data="${kubeadm_data+$kubeadm_data, }\"init\": { \"content\": \"${KUBE_MASTER_AUTOINIT}\" }"
+	kubeadm_data="${kubeadm_data:+$kubeadm_data, }\"init\": { \"content\": \"${KUBE_MASTER_AUTOINIT}\" }"
     fi
     if [ "${KUBE_MASTER_UNTAINT}" = "y" ] ; then
-	kubeadm_data="${kubeadm_data+$kubeadm_data, }\"untaint-master\": { \"content\": \"\" }"
+	kubeadm_data="${kubeadm_data:+$kubeadm_data, }\"untaint-master\": { \"content\": \"\" }"
     fi
 
     state="kube-master-state"

--- a/test/cases/000_smoke/test.exp
+++ b/test/cases/000_smoke/test.exp
@@ -216,6 +216,11 @@ if [string match "Welcome to nginx!" $curl] {
 }
 puts "SUCCESS nginx responded well"
 
+sshcmd "cat cni config" {grep . /var/lib/cni/conf/*.conf /var/lib/cni/conf/*.conflist}
+sshcmd "host ifconfig" {ifconfig -a && route -n && echo && grep . /etc/resolv.conf}
+sshcmd "nginx ifconfig" {kubectl exec $(kubectl get pods -l name==nginx -o=jsonpath='{.items[*].metadata.name}') -- sh -c 'ifconfig -a && route -n && echo && grep . /etc/resolv.conf'}
+sshcmd "alpine ifconfig" {kubectl exec $(kubectl get pods -l name==alpine -o=jsonpath='{.items[*].metadata.name}') -- sh -c 'ifconfig -a && route -n && echo && grep . /etc/resolv.conf'}
+
 # This also happens to test external connectivity...
 sshcmd "alpine install curl" {kubectl exec $(kubectl get pods -l name==alpine -o=jsonpath='{.items[*].metadata.name}') -- apk add --update curl}
 

--- a/yml/bridge.yml
+++ b/yml/bridge.yml
@@ -5,7 +5,7 @@ onboot:
       - "/bin/sh"
       - "-c"
       - |
-        set -ex
+        set -e
         subnet='"10.1.0.0/16"'
         gateway='"10.1.0.1"'
         ns='"10.1.0.1"'
@@ -45,7 +45,11 @@ onboot:
           "type": "loopback"
         }
         EOF
+        if [ -r "/run/config/cni.bridge/debug-show-configs" ] ; then
+            grep . /var/lib/cni/conf/*.conf /var/lib/cni/conf/*.conflist
+        fi
     runtime:
       mkdir: ["/var/lib/cni/conf"]
     binds:
       - /var/lib:/var/lib
+      - /run/config:/run/config

--- a/yml/bridge.yml
+++ b/yml/bridge.yml
@@ -6,9 +6,18 @@ onboot:
       - "-c"
       - |
         set -e
-        subnet='"10.1.0.0/16"'
-        gateway='"10.1.0.1"'
-        ns='"10.1.0.1"'
+        field() {
+            local f=$1
+            local d=$2
+            if [ -r "/run/config/cni.bridge/$f" ] ; then
+                cat "/run/config/cni.bridge/$f"
+            else
+                echo -e "\"$d\"\\n"
+            fi
+        }
+        subnet="$(field subnet '10.1.0.0/16')"
+        gateway="$(field gateway '10.1.0.1')"
+        ns="$(field ns '10.1.0.1')"
         cat <<EOF >/var/lib/cni/conf/10-default.conflist
         {
           "cniVersion": "0.3.1",

--- a/yml/bridge.yml
+++ b/yml/bridge.yml
@@ -6,6 +6,9 @@ onboot:
       - "-c"
       - |
         set -ex
+        subnet='"10.1.0.0/16"'
+        gateway='"10.1.0.1"'
+        ns='"10.1.0.1"'
         cat <<EOF >/var/lib/cni/conf/10-default.conflist
         {
           "cniVersion": "0.3.1",
@@ -19,11 +22,11 @@ onboot:
               "hairpinMode": true,
               "ipam": {
                 "type": "host-local",
-                "subnet": "10.1.0.0/16",
-                "gateway": "10.1.0.1"
+                "subnet": $subnet,
+                "gateway": $gateway
               },
               "dns": {
-                "nameservers": ["10.1.0.1"]
+                "nameservers": [$ns]
               }
             },
             {


### PR DESCRIPTION
Allow the subnet, gateway and nameservers used by CNI bridge mode to be configured, since the defaults may conflict with external configuration.

As part of this enhance the `boot.sh` and test harness to allow testing this. The result has passed:

    KUBE_METADATA='"cni.bridge": { "entries": { "subnet" : {"content": "\"192.168.42.0/24\"" }, "gateway" : {"content": "\"192.168.42.254\""}, "ns": { "content": "\"192.158.42.128\""}, "debug-show-configs" : { "content": "" } } }' rtf run

Including eye-balling the logs for sanity.