### PR TITLE
Bump to CNI v0.7.1

### DIFF
--- a/pkg/kubelet/Dockerfile
+++ b/pkg/kubelet/Dockerfile
@@ -4,7 +4,7 @@ FROM linuxkit/alpine:f3cd219615428b2bd943411723eb28875275fae7 AS build
 # - scripts/mk-image-cache-lst and run `make refresh-image-caches` from top-level
 # - pkg/e2e-test/Dockerfile
 ENV kubernetes_version v1.10.0
-ENV cni_version        v0.7.0
+ENV cni_version        v0.7.1
 ENV critools_version   v1.0.0-alpha.0
 
 RUN apk add -U --no-cache \

--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -40,7 +40,7 @@ services:
     image: linuxkit/sshd:39d6bdc9a7489ceffa761ad5cb96c87b50d6732d
     cgroupsPath: systemreserved/sshd
   - name: kubelet
-    image: linuxkit/kubelet:7663c7ad197bf3d401d93d5bc4c0eabfa2e70f77
+    image: linuxkit/kubelet:ddd2e094e44aae9bab3eb3b8d378d2383d6cda01
     cgroupsPath: podruntime/kubelet
 files:
   - path: etc/linuxkit.yml


### PR DESCRIPTION
https://github.com/containernetworking/plugins/releases/tag/v0.7.1

> This release fixes a regression where the interface's MAC address was no
> longer populated in the return type.

Signed-off-by: Ian Campbell <ijc@docker.com>

RTF tests are building/running now.