### PR TITLE
Explicitly specify -iso for 'linuxkit run'

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -97,4 +97,4 @@ if [ -n "${metadata}" ] ; then
     echo "${metadata}" > $state/metadata.json
 fi
 
-exec linuxkit run ${KUBE_RUN_ARGS} -networking ${KUBE_NETWORKING} -cpus ${KUBE_VCPUS} -mem ${KUBE_MEM} -state "${state}" -disk size=${KUBE_DISK} -data-file $state/metadata.json ${uefi} "${img}${suffix}"
+exec linuxkit run ${KUBE_RUN_ARGS} -networking ${KUBE_NETWORKING} -cpus ${KUBE_VCPUS} -mem ${KUBE_MEM} -state "${state}" -disk size=${KUBE_DISK} -data-file $state/metadata.json -iso ${uefi} "${img}${suffix}"


### PR DESCRIPTION
https://github.com/linuxkit/linuxkit/pull/3002 removed some of
the auto-detection code for booting from an ISO (for hyperkit).

Let's specify '-iso' explicitly.

resolves #76

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>
