### PR TITLE
Update kernel to 4.14.40 for preventing kernel panic

### DIFF
--- a/yml/kube.yml
+++ b/yml/kube.yml
@@ -1,5 +1,5 @@
 kernel:
-  image: linuxkit/kernel:4.14.32
+  image: linuxkit/kernel:4.14.41
   cmdline: "console=tty0 console=ttyS0"
 init:
   - linuxkit/init:be60dd1cb15ad39225512b6753304571d8c2fb17


### PR DESCRIPTION
Fixes: #80

Signed-off-by: Eohyung Lee <liquidnuker@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
update kernel for preventing kernel panic when using vxlan

**- How I did it**
update kernel version to 4.14.40 which included linuxkit/linux@6a3c946

**- How to verify it**

I run with this kernel version about 1-2 hours and there is no kernel panic at all.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update kernel to 4.14.40

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://i2.ruliweb.com/ori/18/05/15/16362d321b5329dfd.gif)