### PR TITLE
Revert "Workaround `rootfsPropagation: shared` brokenness."

### DIFF
--- a/pkg/cri-containerd/Dockerfile
+++ b/pkg/cri-containerd/Dockerfile
@@ -48,7 +48,5 @@ RUN make DESTDIR=/out install
 
 FROM scratch
 WORKDIR /
-# `rootfsPropagation: shared` (used in `build.yml`) appears to be broken at the moment, workaround that issue here.
-#ENTRYPOINT ["cri-containerd", "--log-level", "info", "--network-bin-dir", "/opt/cni/bin", "--network-conf-dir", "/etc/cni/net.d"]
-ENTRYPOINT ["/bin/sh", "-c", "set -ex; mount --make-shared / && exec cri-containerd --log-level info --network-bin-dir /opt/cni/bin --network-conf-dir /etc/cni/net.d"]
+ENTRYPOINT ["cri-containerd", "--log-level", "info", "--network-bin-dir", "/opt/cni/bin", "--network-conf-dir", "/etc/cni/net.d"]
 COPY --from=build /out /

--- a/yml/cri-containerd.yml
+++ b/yml/cri-containerd.yml
@@ -1,6 +1,6 @@
 services:
   - name: cri-containerd
-    image: linuxkit/cri-containerd:093735eea5b3d7488ffc5a0ecf83a08e344f2e4f
+    image: linuxkit/cri-containerd:74cb328b786d5cada9ddfca0097675b51c7e7d93
     cgroupsPath: podruntime/cri-containerd
 files:
   - path: /etc/kubelet.sh.conf

--- a/yml/docker.yml
+++ b/yml/docker.yml
@@ -21,9 +21,7 @@ services:
      - /var/lib/cni/bin:/opt/cni/bin:rshared,rbind
      - /var/lib/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins:rshared,rbind
     rootfsPropagation: shared
-    # `rootfsPropagation: shared` appears to be broken, workaround that issue here.
-    #command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
-    command: ["/bin/sh", "-c", "set -ex; mount --make-shared / && exec /usr/local/bin/docker-init /usr/local/bin/dockerd"]
+    command: ["/usr/local/bin/docker-init", "/usr/local/bin/dockerd"]
     runtime:
       mkdir: ["/var/lib/kubeadm", "/var/lib/cni/conf", "/var/lib/cni/bin", "/var/lib/kubelet-plugins"]
     cgroupsPath: podruntime/docker


### PR DESCRIPTION
This reverts commit 7efaec5886f1fe09a8ac216b9961b75af53bcc8d.

This is not needed since the update to Kubernetes 1.10.3 in #83.

Signed-off-by: Ian Campbell <ijc@docker.com>
